### PR TITLE
Rename static libraries on Windows to match the jpeg recipe's output

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,3 +15,7 @@ if errorlevel 1 exit 1
 REM Install step
 nmake install
 if errorlevel 1 exit 1
+
+REM Rename static libraries to be consistent with conda-forge's jpeg recipe
+move %LIBRARY_PREFIX%\lib\jpeg-static.lib %LIBRARY_PREFIX%\lib\libjpeg.lib
+move %LIBRARY_PREFIX%\lib\turbojpeg-static.lib %LIBRARY_PREFIX%\lib\libturbojpeg.lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 55deb139b0cac3c8200b75d485fc13f3
 
 build:
-    number: 0
+    number: 1
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]


### PR DESCRIPTION
Rename
* `jpeg-static.lib` -> `libjpeg.lib`
* `turbojpeg-static.lib` -> `libturbojpeg.lib`

on Windows to be consistent with the `jpeg` recipe.